### PR TITLE
Delete old getPosts endpoints, edit user, refactoring

### DIFF
--- a/src/main/java/api/Api.java
+++ b/src/main/java/api/Api.java
@@ -214,7 +214,7 @@ public class Api {
 
 		return StatusMonitor.getLastPostId();
 	}
-	
+	/*
 	@RequestMapping("/changeStatus/update")
 	public boolean setUpdate() {
 
@@ -230,7 +230,7 @@ public class Api {
 		logger.warn("Status has been changed to alive. Somebody might be a dick");
 		return true;
 	}
-	
+	*/
 
 	@Bean
 	ServletRegistrationBean servletRegistrationBean() {

--- a/src/main/java/datastructures/EditUserDTO.java
+++ b/src/main/java/datastructures/EditUserDTO.java
@@ -1,0 +1,31 @@
+package datastructures;
+
+public class EditUserDTO {
+
+	private String user_name;
+	private String oldUser_pwd;
+	private String newUser_pwd;
+	
+	public String getUser_name() {
+		return user_name;
+	}
+	public void setUser_name(String oldUser_name) {
+		this.user_name = oldUser_name;
+	}
+	public String getOldUser_pwd() {
+		return oldUser_pwd;
+	}
+	public void setOldUser_pwd(String oldUser_pwd) {
+		this.oldUser_pwd = oldUser_pwd;
+	}
+	public String getNewUser_pwd() {
+		return newUser_pwd;
+	}
+	public void setNewUser_pwd(String newUser_pwd) {
+		this.newUser_pwd = newUser_pwd;
+	}
+	
+	
+	
+	
+}

--- a/src/main/java/datastructures/User.java
+++ b/src/main/java/datastructures/User.java
@@ -4,6 +4,23 @@ public class User {
 	private String user_name;
 	private String user_pwd;
 
+	public User() {
+		
+	}
+	
+	
+	
+	/**
+	 * @param user_name
+	 * @param user_pwd
+	 */
+	public User(String user_name, String user_pwd) {
+		this.user_name = user_name;
+		this.user_pwd = user_pwd;
+	}
+
+
+
 	public String getUser_name() {
 		return user_name;
 	}

--- a/src/main/java/db/neo4j/Neo4jQuery.java
+++ b/src/main/java/db/neo4j/Neo4jQuery.java
@@ -1,8 +1,8 @@
 package db.neo4j;
 
-public interface Neo4jQueryInterface {
+public class Neo4jQuery {
 
-	public default String addPostQuery() {
+	public String addPostQuery() {
 		return "CREATE (:Post { post_title: {post_title}, \n" + 
 				" post_text: {post_text} , \n" + 
 				" hanesst_id: {hanesst_id}, \n" + 
@@ -14,7 +14,7 @@ public interface Neo4jQueryInterface {
 				+ "timestamp: {timestamp}})";
 	}
 	
-	public default String addCommentQuery() {
+	public String addCommentQuery() {
 		return "Match (p:Post) \n" 
 				+ "Where p.hanesst_id={post_parent} \n" 
 				+ "CREATE (:Post { post_title: {post_title}, post_text: {post_text} ,\n" 
@@ -24,24 +24,13 @@ public interface Neo4jQueryInterface {
 				+ "timestamp: {timestamp}})<-[par:Parent]-(p)";
 	}
 	
-	public default String getPostsBySiteQuery() {
+	public String getPostsBySiteQuery() {
 
 		return "MATCH (post:Post) WHERE post.post_url CONTAINS {site} RETURN post order by post.timestamp desc";
 	}
-
-	//To be phased out
-	public default String getPostsLimitQuery(Integer skip, Integer limit) {
-
-		return "MATCH (post:Post) WHERE post.post_parent = -1 RETURN post ORDER BY post.timestamp desc SKIP " + skip + " LIMIT " + limit;
-	}
-	//To be phased out
-	public default String getPostsLimitQuery(Integer limit) {
-
-		return "MATCH (post:Post) WHERE post.post_parent = -1 RETURN post ORDER BY post.timestamp desc LIMIT " + limit;
-	}
 	
 	//Right One
-	public default String getPostsLimitNewQuery(Integer skip, Integer limit) {
+	public String getPostsLimitNewQuery(Integer skip, Integer limit) {
 
 		return "Match (par:Post{post_parent:-1}) \n" + 
 				"       with par ORDER BY par.timestamp desc skip "+skip+" limit "+limit+"\n" + 
@@ -49,26 +38,30 @@ public interface Neo4jQueryInterface {
 				"        return par as post, size((par)-[:Parent *1..]->()) as numberOfcomments;";
 	}
 
-	public default String addUserQuery() {
+	public String addUserQuery() {
 
 		return "CREATE (:User {user_name:{user_name}, user_pwd:{user_pwd}})";
 	}
+	
+	public String editUser(String username, String oldPassword, String newPassword) {
+		return "match (u:User) where u.user_name=\""+username+"\" and u.user_pwd=\""+oldPassword+"\" set u.user_pwd=\""+newPassword+"\" return u;";
+	}
 
-	public default String logInQuery() {
+	public String logInQuery() {
 		return "MATCH (u:User) WHERE u.user_name={user_name} and u.user_pwd={user_pwd} return u";
 	}
 	
-	public default String getCommentsQuery(int hanesst_id) {
+	public String getCommentsQuery(int hanesst_id) {
 		return "MATCH (parent:Post{hanesst_id:"+hanesst_id+"})-[:Parent *1..]->(child:Post) "
 				+ "return parent as story,collect(child) as comments, count(child) as numberOfcomments";
 	}
 	
-	public default String getPostAndCommentsCountQuery(int hanesst_id) {
+	public String getPostAndCommentsCountQuery(int hanesst_id) {
 		return "MATCH (parent:Post{hanesst_id:"+hanesst_id+"})-[:Parent *1..]->(child:Post) "
 				+ "return parent as story,collect(child) as comments, count(child) as numberOfcomments ;";
 	}
 	
-	public default String generateHanesst_idQuery() {
+	public String generateHanesst_idQuery() {
 		return "MATCH (idc:IdCounter)\n" + 
 				"SET idc.counter=idc.counter-1 \n" + 
 				"RETURN idc.counter as id;";

--- a/src/main/java/garbage/test/Main.java
+++ b/src/main/java/garbage/test/Main.java
@@ -10,8 +10,9 @@ public class Main {
 		MyNeo4jMapper mapper = new MyNeo4jMapper();
 
 		//mapper.getComments(445);
+		
 
-		System.out.println();
+		System.out.println(mapper.editUser("pg", "lol6", "lol7"));
 		
 
 	}

--- a/src/main/java/util/JSONMapper.java
+++ b/src/main/java/util/JSONMapper.java
@@ -7,39 +7,27 @@ import org.neo4j.driver.v1.Record;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import datastructures.EditUserDTO;
 import datastructures.User;
 import datastructures.post.PostBody;
 
 public class JSONMapper {
 	
-	public PostBody jsonToPostBody(String json) {
+	//Generics are for real programmers
+	public <T> T jsonToType(Class<T> typeParameterClass, String json) {
 		ObjectMapper om = new ObjectMapper();
-	
-		PostBody pb = null;
+		
+		T output = null;
 		try {
-			pb = om.readValue(json, PostBody.class);
+			output = om.readValue(json, typeParameterClass);
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		
-		return pb;
-
+		return output;
 	}
 	
-	public User jsonToUser(String json) {
-		ObjectMapper om = new ObjectMapper();
-		User u = null;
-		try {
-			JsonNode jsonNode = om.readTree(json);
-			u = om.readValue(json, User.class);
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		return u;
-
-	}
 	
 	public String recordToJson (Record r) {
 		


### PR DESCRIPTION
If you want to change user make a request with something like this:
{"user_name": "pg", 
 "oldUser_pwd": "lol7",
 "newUser_pwd": "lol8"
}

Old getPosts endpoints have been deleted. There is now only one endpoint to get posts under /getPosts